### PR TITLE
Modify/Creation date and time in DS306 format for eds file (h:mmtt MM…

### DIFF
--- a/libEDSsharp/eds.cs
+++ b/libEDSsharp/eds.cs
@@ -1226,11 +1226,11 @@ namespace libEDSsharp
 
             //generate date times in DS306 format; h:mmtt MM-dd-yyyy
 
-            fi.CreationDate = fi.CreationDateTime.ToString("MM-dd-yyyy");
-            fi.CreationTime = fi.CreationDateTime.ToString("h:mmtt");
+            fi.CreationDate = fi.CreationDateTime.ToString("MM-dd-yyyy", CultureInfo.InvariantCulture);
+            fi.CreationTime = fi.CreationDateTime.ToString("h:mmtt", CultureInfo.InvariantCulture);
 
-            fi.ModificationDate = fi.ModificationDateTime.ToString("MM-dd-yyyy");
-            fi.ModificationTime = fi.ModificationDateTime.ToString("h:mmtt");
+            fi.ModificationDate = fi.ModificationDateTime.ToString("MM-dd-yyyy", CultureInfo.InvariantCulture);
+            fi.ModificationTime = fi.ModificationDateTime.ToString("h:mmtt", CultureInfo.InvariantCulture);
 
             fi.FileName = filename;
 


### PR DESCRIPTION
…-dd-yyyy) should be culture invariant.

E.g. German time would be 10:12 in eds instead of 10:12AM, that is not according DS306 (characters in format „hh:mm(AM|PM)“

Added CultureInfo.InvariantCulture for Creation/Modification date and time.