### PR TITLE
Added index and sub-index defines to CANopenNode exporter...

### DIFF
--- a/libEDSsharp/CanOpenNodeExporter.cs
+++ b/libEDSsharp/CanOpenNodeExporter.cs
@@ -388,7 +388,7 @@ namespace libEDSsharp
                 default:
                     {
                         file.WriteLine(string.Format("/*{0:x4} */", od.index));
-                        file.WriteLine(string.Format("        #define {0,-51} 0x{1:x4}", string.Format("OD_INDEX_{0}", make_cname(od.parameter_name)), od.index, t.ToString()));
+                        file.WriteLine(string.Format("        #define {0,-51} 0x{1:x4}", string.Format("OD_{0:x4}_{1}", od.index, make_cname(od.parameter_name)), od.index, t.ToString()));
 
                         file.WriteLine("");
                     }
@@ -398,12 +398,12 @@ namespace libEDSsharp
                 case ObjectType.REC:
                     {
                         file.WriteLine(string.Format("/*{0:x4} */", od.index));
-                        file.WriteLine(string.Format("        #define {0,-51} 0x{1:x4}", string.Format("OD_INDEX_{0}", make_cname(od.parameter_name)), od.index, t.ToString()));
+                        file.WriteLine(string.Format("        #define {0,-51} 0x{1:x4}", string.Format("OD_{0:x4}_{1}", od.index, make_cname(od.parameter_name)), od.index, t.ToString()));
 
                         file.WriteLine("");
 
                         //sub indexes
-                        file.WriteLine(string.Format("        #define {0,-51} 0", string.Format("OD_SUBINDEX_{0}_maxSubIndex", make_cname(od.parameter_name))));         
+                        file.WriteLine(string.Format("        #define {0,-51} 0", string.Format("OD_{0:x4}_0_{1}_maxSubIndex", od.index, make_cname(od.parameter_name))));         
 
                         List<string> ODSIs = new List<string>();
 
@@ -416,7 +416,7 @@ namespace libEDSsharp
                             if (sub.subindex == 0)
                                 continue;
 
-                            string ODSI = string.Format("{0}", string.Format("OD_SUBINDEX_{0}_{1}", make_cname(od.parameter_name), make_cname(sub.parameter_name)));
+                            string ODSI = string.Format("{0}", string.Format("OD_{0:x4}_{1}_{2}_{3}", od.index, sub.subindex, make_cname(od.parameter_name), make_cname(sub.parameter_name)));
 
                             if (ODSIs.Contains(ODSI))
                             {
@@ -425,7 +425,7 @@ namespace libEDSsharp
 
                             ODSIs.Add(ODSI);
 
-                            ODSIout += (string.Format("        #define {0,-51} {1}\r\n", string.Format("OD_SUBINDEX_{0}_{1}", make_cname(od.parameter_name), make_cname(sub.parameter_name)), sub.subindex));
+                            ODSIout += (string.Format("        #define {0,-51} {1}\r\n", ODSI, sub.subindex));
                         }
 
                         file.Write(ODSIout);


### PR DESCRIPTION
some of those indexes are already defined in CO_SDO.h CO_ObjDicId_t <Common CiA301 object dictionary entries>, however those are only the most common ones.
This extends that information to contain all configured OD indexes and sub-indexes. This also has the advantage that it **does not** contain the unused ones.

This makes using the information eg inside struct <CO_ODF_arg_t> index and subIndex easier. You can do something like that:

```
CO_SDO_abortCode_t od_callback(CO_ODF_arg_t *odf_arg)
{
  switch (odf_arg.index) {
    case OD_INDEX_readInput8Bit:
        switch (odf_arg.subIndex) {
            case OD_SUBINDEX_writeOutput8Bit_output07:
                do do_work
                break;
            case OD_SUBINDEX_writeOutput8Bit_output815:
                do do_work
                break;
        break;
    case OD_INDEX_writeOutput8Bit:

    and so on...

  return CO_SDO_AB_NONE;
}
```

the same goes for 

`CO_OD_configure(CO->SDO[0], OD_INDEX_writeOutput8Bit, pODFunc, NULL, NULL, 0);`

instead of 

`CO_OD_configure(CO->SDO[0], 0x6001, pODFunc, NULL, NULL, 0);`

Please give me your opinion if it is better to have Indexes in the names or not
`OD_INDEX_deviceType` or
`OD_INDEX_H1000_deviceType` like in CO_ObjDicId_t
