### PR TITLE
Ignore subindex descripency on object 0x1003

### DIFF
--- a/libEDSsharp/CanOpenNodeExporter.cs
+++ b/libEDSsharp/CanOpenNodeExporter.cs
@@ -643,7 +643,7 @@ const CO_OD_entry_t CO_OD[");
                 //Arrays really should obey the max subindex paramater not the physical number of elements
                 if (od.objecttype == ObjectType.ARRAY)
                 {
-                    if (od.getmaxsubindex() != nosubindexs)
+                    if ((od.getmaxsubindex() != nosubindexs) && (od.index != 0x1003))
                     {
                         Warnings.warning_list.Add(String.Format("Subindex descripency on object 0x{0:x4} arraysize: {1} vs max-subindex: {2}", od.index, nosubindexs, od.getmaxsubindex()));
                     }


### PR DESCRIPTION
As stated before the subindex descripency on object 0x1003 make no sense to warn, because it is the number of errors not the max. subindex.