### PR TITLE
In case of OD ID 0x1003, place actual array size in CANopenNode heade…

### DIFF
--- a/libEDSsharp/CanOpenNodeExporter.cs
+++ b/libEDSsharp/CanOpenNodeExporter.cs
@@ -809,11 +809,11 @@ const CO_OD_entry_t CO_OD[");
                 //Arrays really should obey the max subindex paramater not the physical number of elements
                 if (od.objecttype == ObjectType.ARRAY)
                 {
-                    if ((od.getmaxsubindex() != nosubindexs) && od.index != 0x1003) //ignore this warning on 0x1003 it is a special case
+                    if ((od.getmaxsubindex() != nosubindexs) && od.index != 0x1003) //ignore 0x1003, it is a special case
                     {
                         Warnings.warning_list.Add(String.Format("Subindex discrepancy on object 0x{0:x4} arraysize: {1} vs max-subindex: {2}", od.index, nosubindexs, od.getmaxsubindex()));
+                        nosubindexs = od.getmaxsubindex();
                     }
-                    nosubindexs = od.getmaxsubindex();
                 }
 
                 string pdata; //CO_OD_entry_t pData generator


### PR DESCRIPTION
…r file instead of max index.

this is necessary because ID 0x1003 is handled different to all other entries. CANopenNode handles the differences on the network side, however, it needs to know how much elements are there for error storage.

This fixes https://github.com/robincornelius/libedssharp/issues/82
