### PR TITLE
creating 32 bit value that contained $NODEID triggered exception...

### DIFF
--- a/libEDSsharp/CanOpenNodeExporter.cs
+++ b/libEDSsharp/CanOpenNodeExporter.cs
@@ -962,7 +962,7 @@ const CO_OD_entry_t CO_OD[");
 
             if (nodeidreplace)
             {
-                UInt16 data = Convert.ToUInt16(defaultvalue, nobase);
+                UInt32 data = Convert.ToUInt32(defaultvalue, nobase);
                 data += eds.NodeId;
                 defaultvalue = string.Format("0x{0:x}", data);
                 nobase = 16;


### PR DESCRIPTION
this is the case when setting PDO to default disabled (e.g. 0x80000200+$NODEID).