### PR TITLE
Add support for LSS in CANopenNode

### DIFF
--- a/EDSTest/DeviceInfoView.Designer.cs
+++ b/EDSTest/DeviceInfoView.Designer.cs
@@ -63,6 +63,7 @@
             this.label19 = new System.Windows.Forms.Label();
             this.label18 = new System.Windows.Forms.Label();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
+            this.comboBox_lss = new System.Windows.Forms.ComboBox();
             this.textBox_Gran = new System.Windows.Forms.TextBox();
             this.label31 = new System.Windows.Forms.Label();
             this.checkBox_lss = new System.Windows.Forms.CheckBox();
@@ -92,25 +93,25 @@
             this.groupBox2.SuspendLayout();
             this.groupBox1.SuspendLayout();
             this.SuspendLayout();
-            // 
+            //
             // textBox_concretenodeid
-            // 
+            //
             this.textBox_concretenodeid.Location = new System.Drawing.Point(502, 246);
             this.textBox_concretenodeid.Name = "textBox_concretenodeid";
             this.textBox_concretenodeid.Size = new System.Drawing.Size(80, 20);
             this.textBox_concretenodeid.TabIndex = 54;
-            // 
+            //
             // label32
-            // 
+            //
             this.label32.AutoSize = true;
             this.label32.Location = new System.Drawing.Point(405, 253);
             this.label32.Name = "label32";
             this.label32.Size = new System.Drawing.Size(91, 13);
             this.label32.TabIndex = 53;
             this.label32.Text = "Concrete node ID";
-            // 
+            //
             // button_update_devfile_info
-            // 
+            //
             this.button_update_devfile_info.Location = new System.Drawing.Point(513, 312);
             this.button_update_devfile_info.Name = "button_update_devfile_info";
             this.button_update_devfile_info.Size = new System.Drawing.Size(113, 35);
@@ -118,9 +119,9 @@
             this.button_update_devfile_info.Text = "Update";
             this.button_update_devfile_info.UseVisualStyleBackColor = true;
             this.button_update_devfile_info.Click += new System.EventHandler(this.button_update_devfile_info_Click);
-            // 
+            //
             // groupBox5
-            // 
+            //
             this.groupBox5.Controls.Add(this.textBox_txpdos);
             this.groupBox5.Controls.Add(this.textBox_rxpdos);
             this.groupBox5.Controls.Add(this.label30);
@@ -131,43 +132,43 @@
             this.groupBox5.TabIndex = 51;
             this.groupBox5.TabStop = false;
             this.groupBox5.Text = "PDOs";
-            // 
+            //
             // textBox_txpdos
-            // 
+            //
             this.textBox_txpdos.Location = new System.Drawing.Point(100, 49);
             this.textBox_txpdos.Name = "textBox_txpdos";
             this.textBox_txpdos.ReadOnly = true;
             this.textBox_txpdos.Size = new System.Drawing.Size(101, 20);
             this.textBox_txpdos.TabIndex = 41;
-            // 
+            //
             // textBox_rxpdos
-            // 
+            //
             this.textBox_rxpdos.Location = new System.Drawing.Point(100, 24);
             this.textBox_rxpdos.Name = "textBox_rxpdos";
             this.textBox_rxpdos.ReadOnly = true;
             this.textBox_rxpdos.Size = new System.Drawing.Size(101, 20);
             this.textBox_rxpdos.TabIndex = 40;
-            // 
+            //
             // label30
-            // 
+            //
             this.label30.AutoSize = true;
             this.label30.Location = new System.Drawing.Point(12, 52);
             this.label30.Name = "label30";
             this.label30.Size = new System.Drawing.Size(69, 13);
             this.label30.TabIndex = 39;
             this.label30.Text = "No TX PDOs";
-            // 
+            //
             // label17
-            // 
+            //
             this.label17.AutoSize = true;
             this.label17.Location = new System.Drawing.Point(11, 27);
             this.label17.Name = "label17";
             this.label17.Size = new System.Drawing.Size(70, 13);
             this.label17.TabIndex = 38;
             this.label17.Text = "No RX PDOs";
-            // 
+            //
             // groupBox4
-            // 
+            //
             this.groupBox4.Controls.Add(this.textBox_productnumber);
             this.groupBox4.Controls.Add(this.textBox_productname);
             this.groupBox4.Controls.Add(this.textBox_vendornumber);
@@ -182,73 +183,73 @@
             this.groupBox4.TabIndex = 50;
             this.groupBox4.TabStop = false;
             this.groupBox4.Text = "Device Info";
-            // 
+            //
             // textBox_productnumber
-            // 
+            //
             this.textBox_productnumber.Location = new System.Drawing.Point(137, 45);
             this.textBox_productnumber.Name = "textBox_productnumber";
             this.textBox_productnumber.Size = new System.Drawing.Size(226, 20);
             this.textBox_productnumber.TabIndex = 41;
-            // 
+            //
             // textBox_productname
-            // 
+            //
             this.textBox_productname.Location = new System.Drawing.Point(137, 19);
             this.textBox_productname.Name = "textBox_productname";
             this.textBox_productname.Size = new System.Drawing.Size(226, 20);
             this.textBox_productname.TabIndex = 40;
-            // 
+            //
             // textBox_vendornumber
-            // 
+            //
             this.textBox_vendornumber.Location = new System.Drawing.Point(137, 101);
             this.textBox_vendornumber.Name = "textBox_vendornumber";
             this.textBox_vendornumber.Size = new System.Drawing.Size(226, 20);
             this.textBox_vendornumber.TabIndex = 39;
-            // 
+            //
             // textBox_vendorname
-            // 
+            //
             this.textBox_vendorname.Location = new System.Drawing.Point(137, 75);
             this.textBox_vendorname.Name = "textBox_vendorname";
             this.textBox_vendorname.Size = new System.Drawing.Size(226, 20);
             this.textBox_vendorname.TabIndex = 38;
-            // 
+            //
             // label29
-            // 
+            //
             this.label29.AutoSize = true;
             this.label29.Location = new System.Drawing.Point(9, 48);
             this.label29.Name = "label29";
             this.label29.Size = new System.Drawing.Size(82, 13);
             this.label29.TabIndex = 37;
             this.label29.Text = "Product number";
-            // 
+            //
             // label28
-            // 
+            //
             this.label28.AutoSize = true;
             this.label28.Location = new System.Drawing.Point(9, 25);
             this.label28.Name = "label28";
             this.label28.Size = new System.Drawing.Size(73, 13);
             this.label28.TabIndex = 36;
             this.label28.Text = "Product name";
-            // 
+            //
             // label27
-            // 
+            //
             this.label27.AutoSize = true;
             this.label27.Location = new System.Drawing.Point(9, 104);
             this.label27.Name = "label27";
             this.label27.Size = new System.Drawing.Size(79, 13);
             this.label27.TabIndex = 35;
             this.label27.Text = "Vendor number";
-            // 
+            //
             // label26
-            // 
+            //
             this.label26.AutoSize = true;
             this.label26.Location = new System.Drawing.Point(9, 78);
             this.label26.Name = "label26";
             this.label26.Size = new System.Drawing.Size(70, 13);
             this.label26.TabIndex = 34;
             this.label26.Text = "Vendor name";
-            // 
+            //
             // groupBox3
-            // 
+            //
             this.groupBox3.Controls.Add(this.textBox_modifiedby);
             this.groupBox3.Controls.Add(this.textBox_modified_datetime);
             this.groupBox3.Controls.Add(this.textBox_createdby);
@@ -271,137 +272,138 @@
             this.groupBox3.TabIndex = 49;
             this.groupBox3.TabStop = false;
             this.groupBox3.Text = "EDS File Info";
-            // 
+            //
             // textBox_modifiedby
-            // 
+            //
             this.textBox_modifiedby.Location = new System.Drawing.Point(139, 189);
             this.textBox_modifiedby.Name = "textBox_modifiedby";
             this.textBox_modifiedby.Size = new System.Drawing.Size(226, 20);
             this.textBox_modifiedby.TabIndex = 33;
-            // 
+            //
             // textBox_modified_datetime
-            // 
+            //
             this.textBox_modified_datetime.Location = new System.Drawing.Point(139, 164);
             this.textBox_modified_datetime.Name = "textBox_modified_datetime";
             this.textBox_modified_datetime.Size = new System.Drawing.Size(226, 20);
             this.textBox_modified_datetime.TabIndex = 32;
-            // 
+            //
             // textBox_createdby
-            // 
+            //
             this.textBox_createdby.Location = new System.Drawing.Point(139, 141);
             this.textBox_createdby.Name = "textBox_createdby";
             this.textBox_createdby.Size = new System.Drawing.Size(226, 20);
             this.textBox_createdby.TabIndex = 31;
-            // 
+            //
             // textBox_create_datetime
-            // 
+            //
             this.textBox_create_datetime.Location = new System.Drawing.Point(139, 116);
             this.textBox_create_datetime.Name = "textBox_create_datetime";
             this.textBox_create_datetime.Size = new System.Drawing.Size(226, 20);
             this.textBox_create_datetime.TabIndex = 30;
-            // 
+            //
             // textBox_di_description
-            // 
+            //
             this.textBox_di_description.Location = new System.Drawing.Point(139, 92);
             this.textBox_di_description.Name = "textBox_di_description";
             this.textBox_di_description.Size = new System.Drawing.Size(226, 20);
             this.textBox_di_description.TabIndex = 29;
-            // 
+            //
             // textBox_edsversionm
-            // 
+            //
             this.textBox_edsversionm.Location = new System.Drawing.Point(139, 69);
             this.textBox_edsversionm.Name = "textBox_edsversionm";
             this.textBox_edsversionm.Size = new System.Drawing.Size(226, 20);
             this.textBox_edsversionm.TabIndex = 28;
-            // 
+            //
             // textBox_filerevision
-            // 
+            //
             this.textBox_filerevision.Location = new System.Drawing.Point(139, 44);
             this.textBox_filerevision.Name = "textBox_filerevision";
             this.textBox_filerevision.Size = new System.Drawing.Size(226, 20);
             this.textBox_filerevision.TabIndex = 27;
-            // 
+            //
             // textBox_fileversion
-            // 
+            //
             this.textBox_fileversion.Location = new System.Drawing.Point(139, 22);
             this.textBox_fileversion.Name = "textBox_fileversion";
             this.textBox_fileversion.Size = new System.Drawing.Size(226, 20);
             this.textBox_fileversion.TabIndex = 26;
-            // 
+            //
             // label25
-            // 
+            //
             this.label25.AutoSize = true;
             this.label25.Location = new System.Drawing.Point(11, 192);
             this.label25.Name = "label25";
             this.label25.Size = new System.Drawing.Size(61, 13);
             this.label25.TabIndex = 25;
             this.label25.Text = "Modified by";
-            // 
+            //
             // label24
-            // 
+            //
             this.label24.AutoSize = true;
             this.label24.Location = new System.Drawing.Point(11, 167);
             this.label24.Name = "label24";
             this.label24.Size = new System.Drawing.Size(118, 13);
             this.label24.TabIndex = 24;
             this.label24.Text = "Modification Date/Time";
-            // 
+            //
             // label23
-            // 
+            //
             this.label23.AutoSize = true;
             this.label23.Location = new System.Drawing.Point(11, 144);
             this.label23.Name = "label23";
             this.label23.Size = new System.Drawing.Size(59, 13);
             this.label23.TabIndex = 23;
             this.label23.Text = "Created By";
-            // 
+            //
             // label22
-            // 
+            //
             this.label22.AutoSize = true;
             this.label22.Location = new System.Drawing.Point(11, 119);
             this.label22.Name = "label22";
             this.label22.Size = new System.Drawing.Size(100, 13);
             this.label22.TabIndex = 22;
             this.label22.Text = "Creation Date/Time";
-            // 
+            //
             // label21
-            // 
+            //
             this.label21.AutoSize = true;
             this.label21.Location = new System.Drawing.Point(11, 95);
             this.label21.Name = "label21";
             this.label21.Size = new System.Drawing.Size(60, 13);
             this.label21.TabIndex = 21;
             this.label21.Text = "Description";
-            // 
+            //
             // label20
-            // 
+            //
             this.label20.AutoSize = true;
             this.label20.Location = new System.Drawing.Point(11, 72);
             this.label20.Name = "label20";
             this.label20.Size = new System.Drawing.Size(66, 13);
             this.label20.TabIndex = 20;
             this.label20.Text = "EDS version";
-            // 
+            //
             // label19
-            // 
+            //
             this.label19.AutoSize = true;
             this.label19.Location = new System.Drawing.Point(11, 47);
             this.label19.Name = "label19";
             this.label19.Size = new System.Drawing.Size(62, 13);
             this.label19.TabIndex = 19;
             this.label19.Text = "File revision";
-            // 
+            //
             // label18
-            // 
+            //
             this.label18.AutoSize = true;
             this.label18.Location = new System.Drawing.Point(11, 25);
             this.label18.Name = "label18";
             this.label18.Size = new System.Drawing.Size(60, 13);
             this.label18.TabIndex = 18;
             this.label18.Text = "File version";
-            // 
+            //
             // groupBox2
-            // 
+            //
+            this.groupBox2.Controls.Add(this.comboBox_lss);
             this.groupBox2.Controls.Add(this.textBox_Gran);
             this.groupBox2.Controls.Add(this.label31);
             this.groupBox2.Controls.Add(this.checkBox_lss);
@@ -416,25 +418,38 @@
             this.groupBox2.TabIndex = 48;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Device settings";
-            // 
+            //
+            // comboBox_lss
+            //
+            this.comboBox_lss.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.comboBox_lss.Enabled = false;
+            this.comboBox_lss.FormattingEnabled = true;
+            this.comboBox_lss.Items.AddRange(new object[] {
+            "Server",
+            "Client"});
+            this.comboBox_lss.Location = new System.Drawing.Point(110, 136);
+            this.comboBox_lss.Name = "comboBox_lss";
+            this.comboBox_lss.Size = new System.Drawing.Size(59, 21);
+            this.comboBox_lss.TabIndex = 45;
+            //
             // textBox_Gran
-            // 
+            //
             this.textBox_Gran.Location = new System.Drawing.Point(68, 166);
             this.textBox_Gran.Name = "textBox_Gran";
             this.textBox_Gran.Size = new System.Drawing.Size(59, 20);
             this.textBox_Gran.TabIndex = 44;
-            // 
+            //
             // label31
-            // 
+            //
             this.label31.AutoSize = true;
             this.label31.Location = new System.Drawing.Point(3, 169);
             this.label31.Name = "label31";
             this.label31.Size = new System.Drawing.Size(57, 13);
             this.label31.TabIndex = 41;
             this.label31.Text = "Granularity";
-            // 
+            //
             // checkBox_lss
-            // 
+            //
             this.checkBox_lss.AutoSize = true;
             this.checkBox_lss.Location = new System.Drawing.Point(6, 140);
             this.checkBox_lss.Name = "checkBox_lss";
@@ -442,9 +457,10 @@
             this.checkBox_lss.TabIndex = 40;
             this.checkBox_lss.Text = "LSS Supported";
             this.checkBox_lss.UseVisualStyleBackColor = true;
-            // 
+            this.checkBox_lss.CheckedChanged += new System.EventHandler(this.checkBox_lss_CheckedChanged);
+            //
             // checkBox_boot_master
-            // 
+            //
             this.checkBox_boot_master.AutoSize = true;
             this.checkBox_boot_master.Location = new System.Drawing.Point(6, 48);
             this.checkBox_boot_master.Name = "checkBox_boot_master";
@@ -452,9 +468,9 @@
             this.checkBox_boot_master.TabIndex = 36;
             this.checkBox_boot_master.Text = "Simple bootup master";
             this.checkBox_boot_master.UseVisualStyleBackColor = true;
-            // 
+            //
             // checkBox_group_msg
-            // 
+            //
             this.checkBox_group_msg.AutoSize = true;
             this.checkBox_group_msg.Location = new System.Drawing.Point(6, 117);
             this.checkBox_group_msg.Name = "checkBox_group_msg";
@@ -462,9 +478,9 @@
             this.checkBox_group_msg.TabIndex = 39;
             this.checkBox_group_msg.Text = "Group Messaging";
             this.checkBox_group_msg.UseVisualStyleBackColor = true;
-            // 
+            //
             // checkBox_bootslave
-            // 
+            //
             this.checkBox_bootslave.AutoSize = true;
             this.checkBox_bootslave.Location = new System.Drawing.Point(6, 25);
             this.checkBox_bootslave.Name = "checkBox_bootslave";
@@ -472,9 +488,9 @@
             this.checkBox_bootslave.TabIndex = 35;
             this.checkBox_bootslave.Text = "Simple bootup slave";
             this.checkBox_bootslave.UseVisualStyleBackColor = true;
-            // 
+            //
             // checkBox_compactPDO
-            // 
+            //
             this.checkBox_compactPDO.AutoSize = true;
             this.checkBox_compactPDO.Location = new System.Drawing.Point(6, 94);
             this.checkBox_compactPDO.Name = "checkBox_compactPDO";
@@ -482,9 +498,9 @@
             this.checkBox_compactPDO.TabIndex = 38;
             this.checkBox_compactPDO.Text = "Compact PDO";
             this.checkBox_compactPDO.UseVisualStyleBackColor = true;
-            // 
+            //
             // checkBox_dynamicchan
-            // 
+            //
             this.checkBox_dynamicchan.AutoSize = true;
             this.checkBox_dynamicchan.Location = new System.Drawing.Point(6, 71);
             this.checkBox_dynamicchan.Name = "checkBox_dynamicchan";
@@ -492,9 +508,9 @@
             this.checkBox_dynamicchan.TabIndex = 37;
             this.checkBox_dynamicchan.Text = "Dynamic channels supported";
             this.checkBox_dynamicchan.UseVisualStyleBackColor = true;
-            // 
+            //
             // groupBox1
-            // 
+            //
             this.groupBox1.Controls.Add(this.heckBox_baud_125);
             this.groupBox1.Controls.Add(this.checkBox_baud_10);
             this.groupBox1.Controls.Add(this.heckBox_baud_20);
@@ -509,9 +525,9 @@
             this.groupBox1.TabIndex = 47;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Baudrates";
-            // 
+            //
             // heckBox_baud_125
-            // 
+            //
             this.heckBox_baud_125.AutoSize = true;
             this.heckBox_baud_125.Location = new System.Drawing.Point(18, 100);
             this.heckBox_baud_125.Name = "heckBox_baud_125";
@@ -519,9 +535,9 @@
             this.heckBox_baud_125.TabIndex = 25;
             this.heckBox_baud_125.Text = "125 kbps";
             this.heckBox_baud_125.UseVisualStyleBackColor = true;
-            // 
+            //
             // checkBox_baud_10
-            // 
+            //
             this.checkBox_baud_10.AutoSize = true;
             this.checkBox_baud_10.Location = new System.Drawing.Point(18, 25);
             this.checkBox_baud_10.Name = "checkBox_baud_10";
@@ -529,9 +545,9 @@
             this.checkBox_baud_10.TabIndex = 22;
             this.checkBox_baud_10.Text = "10 kbps";
             this.checkBox_baud_10.UseVisualStyleBackColor = true;
-            // 
+            //
             // heckBox_baud_20
-            // 
+            //
             this.heckBox_baud_20.AutoSize = true;
             this.heckBox_baud_20.Location = new System.Drawing.Point(18, 48);
             this.heckBox_baud_20.Name = "heckBox_baud_20";
@@ -539,9 +555,9 @@
             this.heckBox_baud_20.TabIndex = 23;
             this.heckBox_baud_20.Text = "20 kbps";
             this.heckBox_baud_20.UseVisualStyleBackColor = true;
-            // 
+            //
             // heckBox_baud_50
-            // 
+            //
             this.heckBox_baud_50.AutoSize = true;
             this.heckBox_baud_50.Location = new System.Drawing.Point(18, 73);
             this.heckBox_baud_50.Name = "heckBox_baud_50";
@@ -549,9 +565,9 @@
             this.heckBox_baud_50.TabIndex = 24;
             this.heckBox_baud_50.Text = "50 kbps";
             this.heckBox_baud_50.UseVisualStyleBackColor = true;
-            // 
+            //
             // heckBox_baud_250
-            // 
+            //
             this.heckBox_baud_250.AutoSize = true;
             this.heckBox_baud_250.Location = new System.Drawing.Point(18, 123);
             this.heckBox_baud_250.Name = "heckBox_baud_250";
@@ -559,9 +575,9 @@
             this.heckBox_baud_250.TabIndex = 26;
             this.heckBox_baud_250.Text = "250 kbps";
             this.heckBox_baud_250.UseVisualStyleBackColor = true;
-            // 
+            //
             // heckBox_baud_1000
-            // 
+            //
             this.heckBox_baud_1000.AutoSize = true;
             this.heckBox_baud_1000.Location = new System.Drawing.Point(18, 192);
             this.heckBox_baud_1000.Name = "heckBox_baud_1000";
@@ -569,9 +585,9 @@
             this.heckBox_baud_1000.TabIndex = 29;
             this.heckBox_baud_1000.Text = "1000 kbps";
             this.heckBox_baud_1000.UseVisualStyleBackColor = true;
-            // 
+            //
             // heckBox_baud_500
-            // 
+            //
             this.heckBox_baud_500.AutoSize = true;
             this.heckBox_baud_500.Location = new System.Drawing.Point(18, 146);
             this.heckBox_baud_500.Name = "heckBox_baud_500";
@@ -579,9 +595,9 @@
             this.heckBox_baud_500.TabIndex = 27;
             this.heckBox_baud_500.Text = "500 kbps";
             this.heckBox_baud_500.UseVisualStyleBackColor = true;
-            // 
+            //
             // heckBox_baud_800
-            // 
+            //
             this.heckBox_baud_800.AutoSize = true;
             this.heckBox_baud_800.Location = new System.Drawing.Point(18, 169);
             this.heckBox_baud_800.Name = "heckBox_baud_800";
@@ -589,60 +605,60 @@
             this.heckBox_baud_800.TabIndex = 28;
             this.heckBox_baud_800.Text = "800 kbps";
             this.heckBox_baud_800.UseVisualStyleBackColor = true;
-            // 
+            //
             // label1
-            // 
+            //
             this.label1.AutoSize = true;
             this.label1.Location = new System.Drawing.Point(398, 379);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(111, 13);
             this.label1.TabIndex = 55;
             this.label1.Text = "Device XML file name";
-            // 
+            //
             // textBox_devicefilename
-            // 
+            //
             this.textBox_devicefilename.Location = new System.Drawing.Point(400, 395);
             this.textBox_devicefilename.Name = "textBox_devicefilename";
             this.textBox_devicefilename.ReadOnly = true;
             this.textBox_devicefilename.Size = new System.Drawing.Size(335, 20);
             this.textBox_devicefilename.TabIndex = 34;
-            // 
+            //
             // label2
-            // 
+            //
             this.label2.AutoSize = true;
             this.label2.Location = new System.Drawing.Point(398, 426);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(111, 13);
             this.label2.TabIndex = 56;
             this.label2.Text = "Device EDS file name";
-            // 
+            //
             // textBox_deviceedsname
-            // 
+            //
             this.textBox_deviceedsname.Location = new System.Drawing.Point(400, 440);
             this.textBox_deviceedsname.Name = "textBox_deviceedsname";
             this.textBox_deviceedsname.ReadOnly = true;
             this.textBox_deviceedsname.Size = new System.Drawing.Size(335, 20);
             this.textBox_deviceedsname.TabIndex = 57;
-            // 
+            //
             // textBox_exportfolder
-            // 
+            //
             this.textBox_exportfolder.Location = new System.Drawing.Point(400, 483);
             this.textBox_exportfolder.Name = "textBox_exportfolder";
             this.textBox_exportfolder.ReadOnly = true;
             this.textBox_exportfolder.Size = new System.Drawing.Size(335, 20);
             this.textBox_exportfolder.TabIndex = 58;
-            // 
+            //
             // label3
-            // 
+            //
             this.label3.AutoSize = true;
             this.label3.Location = new System.Drawing.Point(398, 467);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(77, 13);
             this.label3.TabIndex = 59;
             this.label3.Text = "Export location";
-            // 
+            //
             // DeviceInfoView
-            // 
+            //
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.label3);
@@ -736,5 +752,6 @@
         private System.Windows.Forms.TextBox textBox_deviceedsname;
         private System.Windows.Forms.TextBox textBox_exportfolder;
         private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.ComboBox comboBox_lss;
     }
 }

--- a/EDSTest/DeviceInfoView.cs
+++ b/EDSTest/DeviceInfoView.cs
@@ -80,6 +80,14 @@ namespace ODEditor
             checkBox_group_msg.Checked = eds.di.GroupMessaging;
             checkBox_dynamicchan.Checked = eds.di.DynamicChannelsSupported;
             checkBox_lss.Checked = eds.di.LSS_Supported;
+            if (eds.di.LSS_Type == "Client")
+            {
+                comboBox_lss.SelectedItem = "Client";
+            }
+            else
+            {
+                comboBox_lss.SelectedItem = "Server";
+            }
             textBox_Gran.Text = eds.di.Granularity.ToString();
 
             textBox_rxpdos.Text = eds.di.NrOfRXPDO.ToString();
@@ -156,6 +164,7 @@ namespace ODEditor
                 eds.di.GroupMessaging = checkBox_group_msg.Checked;
                 eds.di.DynamicChannelsSupported = checkBox_dynamicchan.Checked;
                 eds.di.LSS_Supported = checkBox_lss.Checked;
+                eds.di.LSS_Type = comboBox_lss.SelectedItem.ToString();
                 eds.di.Granularity = Convert.ToByte(textBox_Gran.Text);
 
                 eds.di.concreteNodeId = -1;
@@ -179,6 +188,17 @@ namespace ODEditor
             }
 
         }
-    
+
+        private void checkBox_lss_CheckedChanged(object sender, EventArgs e)
+        {
+            if (checkBox_lss.Checked)
+            {
+                comboBox_lss.Enabled = true;
+            }
+            else
+            {
+                comboBox_lss.Enabled = false;
+            }
+        }
     }
 }

--- a/libEDSsharp/Bridge.cs
+++ b/libEDSsharp/Bridge.cs
@@ -198,6 +198,7 @@ namespace libEDSsharp
             dev.Other.Capabilities.CharacteristicsList.Characteristic.Add(makecharcteristic("CompactPDO", eds.di.CompactPDO.ToString()));
             dev.Other.Capabilities.CharacteristicsList.Characteristic.Add(makecharcteristic("GroupMessaging", eds.di.GroupMessaging.ToString()));
             dev.Other.Capabilities.CharacteristicsList.Characteristic.Add(makecharcteristic("LSS_Supported", eds.di.LSS_Supported.ToString()));
+            dev.Other.Capabilities.CharacteristicsList.Characteristic.Add(makecharcteristic("LSS_Type", eds.di.LSS_Type));
 
             dev.Other.Capabilities.CharacteristicsList.Characteristic.Add(makecharcteristic("Granularity", eds.di.Granularity.ToString()));
 
@@ -461,6 +462,9 @@ namespace libEDSsharp
                 eds.di.GroupMessaging = boolout;
             if (keypairs.ContainsKey("LSS_Supported") && bool.TryParse(keypairs["LSS_Supported"], out boolout))
                 eds.di.LSS_Supported = boolout;
+
+            if (keypairs.ContainsKey("LSS_Type"))
+                eds.di.LSS_Type = keypairs["LSS_Type"].ToString();
 
             byte byteout;
             if (keypairs.ContainsKey("Granularity") && byte.TryParse(keypairs["Granularity"], out byteout))

--- a/libEDSsharp/CanOpenNodeExporter.cs
+++ b/libEDSsharp/CanOpenNodeExporter.cs
@@ -375,6 +375,19 @@ namespace libEDSsharp
             file.WriteLine(string.Format("  #define CO_NO_SDO_SERVER               {0}   //Associated objects: 1200-127F", noSDOservers));
             file.WriteLine(string.Format("  #define CO_NO_SDO_CLIENT               {0}   //Associated objects: 1280-12FF", noSDOclients));
 
+            int lssServer = 0;
+            if (eds.di.LSS_Supported == true && eds.di.LSS_Type == "Server")
+            {
+                lssServer = 1;
+            }
+            file.WriteLine(string.Format("  #define CO_NO_LSS_SERVER               {0}   //LSS Slave", lssServer));
+            int lssClient = 0;
+            if (eds.di.LSS_Supported == true && eds.di.LSS_Type == "Client")
+            {
+                lssClient = 1;
+            }
+            file.WriteLine(string.Format("  #define CO_NO_LSS_CLIENT               {0}   //LSS Master", lssClient));
+
             file.WriteLine(string.Format("  #define CO_NO_RPDO                     {0}   //Associated objects: 14xx, 16xx", noRXpdos));
             file.WriteLine(string.Format("  #define CO_NO_TPDO                     {0}   //Associated objects: 18xx, 1Axx", noTXpdos));
 

--- a/libEDSsharp/eds.cs
+++ b/libEDSsharp/eds.cs
@@ -622,6 +622,9 @@ namespace libEDSsharp
         [EdsExport]
         public bool LSS_Supported;
 
+        //[EdsExport] @fixme place this in EDS as comment
+        public string LSS_Type = "";
+
         public DeviceInfo(Dictionary<string, string> section)
         {
             infoheader = "CAN OPEN DeviceInfo";


### PR DESCRIPTION
This adds support for the LSS Addon which I added to CANopenNode (see https://github.com/CANopenNode/CANopenNode/issues/47 for more info).
When LSS is enabled, the user can select between server and client implementation, the output is then written to canopennode .h file define list.
Unfortunately, .eds doesn't support differentiation between server and client.

As far as I can see, this should not have any side effects. When LSS addon is not present, the defines are just not used by the stack.

Please have a look that I didn't miss a variable to set...