### PR TITLE
Add default value for lss

### DIFF
--- a/libEDSsharp/eds.cs
+++ b/libEDSsharp/eds.cs
@@ -623,7 +623,7 @@ namespace libEDSsharp
         public bool LSS_Supported;
 
         //[EdsExport] @fixme place this in EDS as comment
-        public string LSS_Type = "";
+        public string LSS_Type = "Server";
 
         public DeviceInfo(Dictionary<string, string> section)
         {


### PR DESCRIPTION
Set a default value for stored LSS type. Without this, it can happen that an empty string is stored to xml. If you try to load such a file you get an error message, caused by the line
```
            if (keypairs.ContainsKey("LSS_Type"))
                eds.di.LSS_Type = keypairs["LSS_Type"].ToString();
```
failing. The default string makes that there is always a correct value stored.

A broken file can be repaired by replacing
```
          <characteristicName>
            <label>LSS_Type</label>
          </characteristicName>
          <characteristicContent>
            <label />
          </characteristicContent>
```
with
```
          <characteristicName>
            <label>LSS_Type</label>
          </characteristicName>
          <characteristicContent>
            <label>Server</label>
          </characteristicContent>
```