### PR TITLE
Added option to add new memory regions to CANopenNode...

### DIFF
--- a/EDSTest/DeviceODView.Designer.cs
+++ b/EDSTest/DeviceODView.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace ODEditor
+namespace ODEditor
 {
     partial class DeviceODView
     {
@@ -523,6 +523,7 @@
             this.comboBox_memory.Name = "comboBox_memory";
             this.comboBox_memory.Size = new System.Drawing.Size(122, 21);
             this.comboBox_memory.TabIndex = 25;
+            this.comboBox_memory.SelectedIndexChanged += new System.EventHandler(this.comboBox_memory_SelectedIndexChanged);
             // 
             // label_index
             // 

--- a/EDSTest/DeviceODView.cs
+++ b/EDSTest/DeviceODView.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
     This file is part of libEDSsharp.
 
     libEDSsharp is free software: you can redistribute it and/or modify
@@ -63,10 +63,7 @@ namespace ODEditor
 
             comboBox_accesstype.Items.Add("0x1003 rw/ro");
 
-            foreach (StorageLocation foo in Enum.GetValues(typeof(StorageLocation)))
-            {
-                comboBox_memory.Items.Add(foo.ToString());
-            }
+            comboBox_memory.Items.Add("Add...");
 
             comboBox_pdomap.Items.Add("no");
             comboBox_pdomap.Items.Add("optional");
@@ -148,7 +145,7 @@ namespace ODEditor
                 selectedobject.AccessFunctionPreCode = textBox_precode.Text;
                 selectedobject.Disabled = !checkBox_enabled.Checked;
 
-                selectedobject.location = (StorageLocation)Enum.Parse(typeof(StorageLocation), comboBox_memory.SelectedItem.ToString());
+                selectedobject.StorageLocation = comboBox_memory.SelectedItem.ToString();
 
             }
 
@@ -179,7 +176,7 @@ namespace ODEditor
                 foreach (KeyValuePair<UInt16, ODentry> kvp in selectedobject.subobjects)
                 {
                     ODentry subod = kvp.Value;
-                    subod.location = selectedobject.location;
+                    subod.StorageLocation = selectedobject.StorageLocation;
                 }
             }
 
@@ -264,7 +261,7 @@ namespace ODEditor
             textBox_precode.Text = od.AccessFunctionPreCode;
             checkBox_enabled.Checked = !od.Disabled;
 
-            comboBox_memory.SelectedItem = od.location.ToString();
+            comboBox_memory.SelectedItem = od.StorageLocation;
 
             textBox_accessfunctionname.Enabled = true;
             textBox_precode.Enabled = true;
@@ -616,6 +613,22 @@ namespace ODEditor
 
         }
 
+        public void populatememorytypes()
+        {
+            if (eds == null)
+                return;
+
+            foreach (string location in eds.storageLocation)
+            {
+                if (location == "Unused")
+                {
+                    continue;
+                }
+                /* add string to the second to last position (before "add...") */
+                comboBox_memory.Items.Insert(comboBox_memory.Items.Count - 1,  location.ToString());
+            }
+        }
+        
         public void populateindexlists()
         {
 
@@ -705,7 +718,7 @@ namespace ODEditor
 
                 od.objecttype = ni.ot;
                 od.index = ni.index;
-                od.location = StorageLocation.RAM;
+                od.StorageLocation = "RAM";
                 od.defaultvalue = "";
                 od.accesstype = EDSsharp.AccessType.rw;
                 od.datatype = ni.dt;
@@ -719,7 +732,7 @@ namespace ODEditor
                         sod.objecttype = ObjectType.VAR;
                         sod.subindex = 0;
                         sod.index = ni.index;
-                        sod.location = StorageLocation.RAM;
+                        sod.StorageLocation = "RAM";
                         sod.defaultvalue = String.Format("{0}",ni.nosubindexes);
                         sod.accesstype = EDSsharp.AccessType.ro;
                         sod.datatype = DataType.UNSIGNED8;
@@ -738,7 +751,7 @@ namespace ODEditor
                         sod.objecttype = ObjectType.VAR;
                         sod.subindex = (UInt16)(p + 1);
                         sod.index = ni.index;
-                        sod.location = StorageLocation.RAM;
+                        sod.StorageLocation = "RAM";
                         sod.defaultvalue = "";
                         sod.accesstype = EDSsharp.AccessType.rw;
                         sod.datatype = ni.dt;
@@ -1028,6 +1041,24 @@ namespace ODEditor
             }
 
             return false;
+        }
+
+        private void comboBox_memory_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            if (comboBox_memory.SelectedItem.ToString() == "Add...")
+            {
+                NewMemoryType memory = new NewMemoryType();
+                if (memory.ShowDialog() == DialogResult.OK)
+                {
+                    if (comboBox_memory.FindStringExact(memory.name) == -1)
+                    {
+                        /* add string to the second to last position (before "add...") */
+                        comboBox_memory.Items.Insert(comboBox_memory.Items.Count - 1, memory.name);
+                        /* add new memory location to eds backend */
+                        eds.storageLocation.Add(memory.name);
+                    }
+                }
+            }
         }
     }
 

--- a/EDSTest/DeviceView.cs
+++ b/EDSTest/DeviceView.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
     This file is part of libEDSsharp.
 
     libEDSsharp is free software: you can redistribute it and/or modify
@@ -94,6 +94,7 @@ namespace ODEditor
                 return;
 
             deviceODView1.eds = eds;
+            deviceODView1.populatememorytypes();
             deviceODView1.populateindexlists();
             deviceODView1.validateanddisplaydata();
             deviceODView1.updateselectedindexdisplay();

--- a/EDSTest/EDSEditorGUI.csproj
+++ b/EDSTest/EDSEditorGUI.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -115,6 +115,12 @@
     <Compile Include="NewIndex.Designer.cs">
       <DependentUpon>NewIndex.cs</DependentUpon>
     </Compile>
+    <Compile Include="NewMemoryType.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="NewMemoryType.Designer.cs">
+      <DependentUpon>NewMemoryType.cs</DependentUpon>
+    </Compile>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ReportView.cs">
@@ -149,6 +155,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="NewIndex.resx">
       <DependentUpon>NewIndex.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="NewMemoryType.resx">
+      <DependentUpon>NewMemoryType.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>

--- a/EDSTest/NewMemoryType.Designer.cs
+++ b/EDSTest/NewMemoryType.Designer.cs
@@ -1,0 +1,96 @@
+namespace ODEditor
+{
+    partial class NewMemoryType
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.button_create = new System.Windows.Forms.Button();
+            this.button_cancel = new System.Windows.Forms.Button();
+            this.label2 = new System.Windows.Forms.Label();
+            this.textBox_name = new System.Windows.Forms.TextBox();
+            this.SuspendLayout();
+            // 
+            // button_create
+            // 
+            this.button_create.Location = new System.Drawing.Point(15, 86);
+            this.button_create.Name = "button_create";
+            this.button_create.Size = new System.Drawing.Size(108, 37);
+            this.button_create.TabIndex = 7;
+            this.button_create.Text = "Create";
+            this.button_create.UseVisualStyleBackColor = true;
+            this.button_create.Click += new System.EventHandler(this.button_create_Click);
+            // 
+            // button_cancel
+            // 
+            this.button_cancel.Location = new System.Drawing.Point(153, 86);
+            this.button_cancel.Name = "button_cancel";
+            this.button_cancel.Size = new System.Drawing.Size(108, 37);
+            this.button_cancel.TabIndex = 8;
+            this.button_cancel.Text = "Cancel";
+            this.button_cancel.UseVisualStyleBackColor = true;
+            this.button_cancel.Click += new System.EventHandler(this.button_cancel_Click);
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(12, 38);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(35, 13);
+            this.label2.TabIndex = 9;
+            this.label2.Text = "Name";
+            // 
+            // textBox_name
+            // 
+            this.textBox_name.Location = new System.Drawing.Point(53, 35);
+            this.textBox_name.Name = "textBox_name";
+            this.textBox_name.Size = new System.Drawing.Size(208, 20);
+            this.textBox_name.TabIndex = 10;
+            // 
+            // NewMemoryType
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(285, 139);
+            this.Controls.Add(this.textBox_name);
+            this.Controls.Add(this.label2);
+            this.Controls.Add(this.button_cancel);
+            this.Controls.Add(this.button_create);
+            this.Name = "NewMemoryType";
+            this.Text = "Add persistent memory type";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Button button_create;
+        private System.Windows.Forms.Button button_cancel;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.TextBox textBox_name;
+    }
+}

--- a/EDSTest/NewMemoryType.cs
+++ b/EDSTest/NewMemoryType.cs
@@ -1,0 +1,65 @@
+/*
+    This file is part of libEDSsharp.
+
+    libEDSsharp is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    libEDSsharp is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with libEDSsharp.  If not, see <http://www.gnu.org/licenses/>.
+ 
+    Copyright(c) 2016 Robin Cornelius <robin.cornelius@gmail.com>
+    Copyright(c) 2017 Neuberger Gebäudeautomation martin.wagner@neuberger.net>
+*/
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace ODEditor
+{
+    public partial class NewMemoryType : Form
+    {
+        public string name;
+
+        public NewMemoryType()
+        {
+            InitializeComponent();
+
+            DialogResult = DialogResult.Cancel;
+        }
+
+        private void button_cancel_Click(object sender, EventArgs e)
+        {
+            Close();
+        }
+
+        private void button_create_Click(object sender, EventArgs e)
+        {
+
+            name = textBox_name.Text;
+
+            if (name == "")
+            {
+                MessageBox.Show("Please specify a name");
+                return;
+            }
+
+            MessageBox.Show(String.Format("You have to manually add the corresponding entries in OD 0x1010 and 0x1011."));
+            DialogResult = DialogResult.OK;
+            Close();
+        }
+    }
+}

--- a/EDSTest/NewMemoryType.resx
+++ b/EDSTest/NewMemoryType.resx
@@ -117,10 +117,4 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="contextMenuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>328, 17</value>
-  </metadata>
-  <metadata name="contextMenu_array.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>483, 17</value>
-  </metadata>
 </root>

--- a/libEDSsharp/Bridge.cs
+++ b/libEDSsharp/Bridge.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
     This file is part of libEDSsharp.
 
     libEDSsharp is free software: you can redistribute it and/or modify
@@ -57,7 +57,8 @@ namespace libEDSsharp
                     coo.Name = od.parameter_name;
                     coo.ObjectType = od.objecttype.ToString();
                     coo.Disabled = od.Disabled.ToString().ToLower();
-                    coo.MemoryType = od.location.ToString();
+                    coo.MemoryType = od.StorageLocation;
+                    eds.storageLocation.Add(od.StorageLocation);
                     coo.AccessType = od.accesstype.ToString();
                     coo.DataType = string.Format("0x{0:x2}",(int)od.datatype);
                     coo.DefaultValue = od.defaultvalue;
@@ -329,10 +330,13 @@ namespace libEDSsharp
 
                 if(coo.Label!=null)
                     entry.Label = coo.Label.Text; //FIXME LANG
-                
-                if(coo.MemoryType!=null)
-                    entry.location = (StorageLocation)Enum.Parse(typeof(StorageLocation), coo.MemoryType);
-                
+
+                if (coo.MemoryType != null)
+                {
+                    entry.StorageLocation = coo.MemoryType;
+                    eds.storageLocation.Add(coo.MemoryType);
+                }
+
                 eds.ods.Add(entry.index, entry);
 
                 if (entry.index == 0x1000 || entry.index==0x1001 || entry.index==0x1018)
@@ -379,7 +383,7 @@ namespace libEDSsharp
                         subentry.PDOtype = entry.PDOtype;
                     }
 
-                    subentry.location = entry.location;
+                    subentry.StorageLocation = entry.StorageLocation;
                     subentry.parent = entry;
 
                     subentry.objecttype = ObjectType.VAR;

--- a/libEDSsharp/CanOpenNodeExporter.cs
+++ b/libEDSsharp/CanOpenNodeExporter.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
     This file is part of libEDSsharp.
 
     libEDSsharp is free software: you can redistribute it and/or modify
@@ -166,7 +166,7 @@ namespace libEDSsharp
         }
 
 
-        private void print_h_bylocation(StreamWriter file, StorageLocation location)
+        private void print_h_bylocation(StreamWriter file, string location)
         {
 
             string lastname = "";
@@ -178,12 +178,12 @@ namespace libEDSsharp
                 if (od.Disabled == true)
                     continue;
 
-                if ((od.location != location))
+                if ((od.StorageLocation != location))
                 {
-                    if (!(od.location == 0 && location == StorageLocation.RAM))
+                    if (!(od.StorageLocation == "Unused" && location == "RAM"))
+                        /* this entry doesn't belong in this section */
                         continue;
                 }
-
 
                 if (od.nosubindexes == 0)
                 {
@@ -543,52 +543,50 @@ namespace libEDSsharp
    STRUCTURES FOR VARIABLES IN DIFFERENT MEMORY LOCATIONS
 *******************************************************************************/
 #define  CO_OD_FIRST_LAST_WORD     0x55 //Any value from 0x01 to 0xFE. If changed, EEPROM will be reinitialized.
-
-/***** Structure for RAM variables ********************************************/
-struct sCO_OD_RAM{
-               UNSIGNED32     FirstWord;
 ");
+            foreach (string location in eds.storageLocation)
+            {
+                if (location == "Unused")
+                {
+                    continue;
+                }
 
-            print_h_bylocation(file, StorageLocation.RAM);
-
-            file.WriteLine(@"
-               UNSIGNED32     LastWord;
-};");
-
-            file.WriteLine(@"/***** Structure for EEPROM variables *****************************************/
-struct sCO_OD_EEPROM{
-               UNSIGNED32     FirstWord;
-
-
-");
-            print_h_bylocation(file, StorageLocation.EEPROM);
-
-            file.WriteLine(@"
-               UNSIGNED32     LastWord;
-};");
-
-            file.WriteLine(@"/***** Structure for ROM variables ********************************************/
-struct sCO_OD_ROM{
+                file.Write("/***** Structure for ");
+                file.Write(location);
+                file.WriteLine(" variables ********************************************/");
+                file.Write("struct sCO_OD_");
+                file.Write(location);
+                file.Write(@"{
                UNSIGNED32     FirstWord;
 
-
 ");
-            print_h_bylocation(file, StorageLocation.ROM);
 
-            file.WriteLine(@"
+                print_h_bylocation(file, location);
+
+                file.WriteLine(@"
                UNSIGNED32     LastWord;
-};");
+};
+");
+            }
 
+            file.WriteLine(@"/***** Declaration of Object Dictionary variables *****************************/");
 
-            file.WriteLine(@"/***** Declaration of Object Dictionary variables *****************************/
-extern struct sCO_OD_RAM CO_OD_RAM;
+            foreach (string location in eds.storageLocation)
+            {
+                if (location == "Unused")
+                {
+                    continue;
+                }
+                
+                file.Write("extern struct sCO_OD_");
+                file.Write(location);
+                file.Write(" CO_OD_");
+                file.Write(location);
+                file.WriteLine(@";
+");
+            }
 
-extern struct sCO_OD_EEPROM CO_OD_EEPROM;
-
-extern struct sCO_OD_ROM CO_OD_ROM;
-
-
-/*******************************************************************************
+file.WriteLine(@"/*******************************************************************************
    ALIASES FOR OBJECT DICTIONARY VARIABLES
 *******************************************************************************/");
 
@@ -603,7 +601,7 @@ extern struct sCO_OD_ROM CO_OD_ROM;
 				if (od.Disabled == true)
 					continue;
 
-                string loc = getlocation(od.location);
+                string loc = "CO_OD_" + od.StorageLocation;
 
                 DataType t = eds.getdatatype(od);
 
@@ -707,43 +705,37 @@ extern struct sCO_OD_ROM CO_OD_ROM;
    DEFINITION AND INITIALIZATION OF OBJECT DICTIONARY VARIABLES
 *******************************************************************************/
 
-/***** Definition for RAM variables *******************************************/
-struct sCO_OD_RAM CO_OD_RAM = {
+");
+            foreach (string location in eds.storageLocation)
+            {
+                if (location == "Unused")
+                {
+                    continue;
+                }
+
+                file.Write("/***** Definition for ");
+                file.Write(location);
+                file.WriteLine(" variables ********************************************/");
+                file.Write("struct sCO_OD_");
+                file.Write(location);
+                file.Write(" CO_OD_");
+                file.Write(location);
+                file.Write(@" = {
            CO_OD_FIRST_LAST_WORD,
+
 ");
 
-            export_OD_def_array(file, StorageLocation.RAM);
+                export_OD_def_array(file, location);
+
+                file.WriteLine(@"
+           CO_OD_FIRST_LAST_WORD,
+};
+
+");
+            }
+
 
             file.WriteLine(@"
-           CO_OD_FIRST_LAST_WORD,
-};
-
-/***** Definition for EEPROM variables ****************************************/
-struct sCO_OD_EEPROM CO_OD_EEPROM = {
-           CO_OD_FIRST_LAST_WORD,
-");
-
-
-            export_OD_def_array(file, StorageLocation.EEPROM);
-
-            file.WriteLine(@"  CO_OD_FIRST_LAST_WORD,
-};
-
-
-/***** Definition for ROM variables *******************************************/
-struct sCO_OD_ROM CO_OD_ROM = {    //constant variables, stored in flash
-           CO_OD_FIRST_LAST_WORD,
-
-");
-
-
-            export_OD_def_array(file, StorageLocation.ROM);
-
-            file.WriteLine(@"
-
-           CO_OD_FIRST_LAST_WORD
-};
-
 
 /*******************************************************************************
    STRUCTURES FOR RECORD TYPE OBJECTS
@@ -775,7 +767,7 @@ const CO_OD_entry_t CO_OD[");
                 if (od.Disabled == true)
                     continue;
 
-                string loc = getlocation(od.location);
+                string loc = "CO_OD_" + od.StorageLocation;
 
                 byte flags = getflags(od);
 
@@ -879,7 +871,12 @@ const CO_OD_entry_t CO_OD[");
             if (od.objecttype == ObjectType.REC)
                 return 0;
 
-            flags = (byte)od.location;
+            flags = (byte)eds.storageLocation.IndexOf(od.StorageLocation);
+            //1 = ROM, 2 = RAM, >= 3 some EEPROM region
+            if (flags > 0x03)
+            {
+                flags = 0x03;
+            }
 
             /* some exceptions for rwr/rww. Those are entries that are always r/w via SDO transfer, 
              * but can only be read -or- written via PDO */
@@ -934,28 +931,6 @@ const CO_OD_entry_t CO_OD[");
 
             return flags;
 
-        }
-
-
-        string getlocation(StorageLocation location)
-        {
-            string loc;
-            switch (location)
-            {
-                case StorageLocation.ROM:
-                    loc = "CO_OD_ROM";
-                    break;
-                default:
-                case StorageLocation.RAM:
-                    loc = "CO_OD_RAM";
-                    break;
-                case StorageLocation.EEPROM:
-                    loc = "CO_OD_EEPROM";
-                    break;
-
-            }
-
-            return loc;
         }
 
         string formatvaluewithdatatype(string defaultvalue, DataType dt)
@@ -1223,12 +1198,12 @@ const CO_OD_entry_t CO_OD[");
 
                     if (sub.datatype != DataType.DOMAIN)
                     {
-                        file.WriteLine(string.Format("           {{(void*)&{5}.{0}{4}.{1}, 0x{2:x2}, 0x{3} }},", cname, subcname, getflags(sub), sub.sizeofdatatype(), arrayaccess, getlocation(od.location)));
+                        file.WriteLine(string.Format("           {{(void*)&{5}.{0}{4}.{1}, 0x{2:x2}, 0x{3} }},", cname, subcname, getflags(sub), sub.sizeofdatatype(), arrayaccess, "CO_OD_" + od.StorageLocation));
                     }
                     else
                     {
                         //Domain type MUST have its data pointer set to 0 for CanOpenNode
-                        file.WriteLine(string.Format("           {{(void*)0, 0x{2:x2}, 0x{3} }},", cname, subcname, getflags(sub), sub.sizeofdatatype(), arrayaccess, getlocation(od.location)));
+                        file.WriteLine(string.Format("           {{(void*)0, 0x{2:x2}, 0x{3} }},", cname, subcname, getflags(sub), sub.sizeofdatatype(), arrayaccess, "CO_OD_" + od.StorageLocation));
                     }
                 }
 
@@ -1318,7 +1293,7 @@ const CO_OD_entry_t CO_OD[");
         }
 
 
-        void export_OD_def_array(StreamWriter file, StorageLocation location)
+        void export_OD_def_array(StreamWriter file, string location)
         {
 
             foreach (KeyValuePair<UInt16, ODentry> kvp in eds.ods)
@@ -1328,9 +1303,10 @@ const CO_OD_entry_t CO_OD[");
                 if (od.Disabled == true)
                     continue;
 
-                if ((od.location != location))
+                if ((od.StorageLocation != location))
                 {
-                    if (!(od.location == 0 && location == StorageLocation.RAM))
+                    if (!(od.StorageLocation == "Unused" && location == "RAM"))
+                        /* this entry doesn't belong in this section */
                         continue;
                 }
 

--- a/libEDSsharp/DocumentationGen.cs
+++ b/libEDSsharp/DocumentationGen.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
     This file is part of libEDSsharp.
 
     libEDSsharp is free software: you can redistribute it and/or modify
@@ -126,7 +126,7 @@ namespace libEDSsharp
             write2linetablerow("Data Type", dt.ToString());
             write2linetablerow("Default Value", od.defaultvalue);
 
-            write2linetablerow("Location", od.location.ToString());
+            write2linetablerow("Location", od.StorageLocation);
             write2linetablerow("Access type", od.accesstype.ToString());
             write2linetablerow("PDO mapping", od.PDOMapping);
             write2linetablerow("No Sub index", od.nosubindexes);

--- a/libEDSsharp/eds.cs
+++ b/libEDSsharp/eds.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
     This file is part of libEDSsharp.
 
     libEDSsharp is free software: you can redistribute it and/or modify
@@ -81,11 +81,26 @@ namespace libEDSsharp
     }
 
     //Additional Info for CANOpenNode c and h generation
-    public enum StorageLocation
+    public class StorageLocation : List<string>
     {
-        ROM=1,
-        RAM=2,
-        EEPROM=3,
+        public StorageLocation()
+        {
+            /* those are the values used in CANopenNode, starting at index "1".
+             * Don't change the indexes, they are also used as binary flags */
+            Add("Unused");
+            Add("ROM");
+            Add("RAM");
+            Add("EEPROM");
+        }
+
+        new public void Add(string item)
+        {
+            /* we check if the storage location already exists */
+            if ( ! Contains(item))
+            {
+                base.Add(item);
+            }
+        }
     }
 
     public enum PDOMappingType
@@ -698,7 +713,7 @@ namespace libEDSsharp
         public string Label = "";
         public string Description = "";
 
-        public StorageLocation location = StorageLocation.RAM;
+        public string StorageLocation = "RAM";
         public SortedDictionary<UInt16, ODentry> subobjects = new SortedDictionary<UInt16, ODentry>();
         public ODentry parent = null;
 
@@ -790,7 +805,7 @@ namespace libEDSsharp
 
             writer.WriteLine(string.Format("ParameterName={0}", parameter_name));
             writer.WriteLine(string.Format("ObjectType=0x{0:X}", (int)objecttype));
-            writer.WriteLine(string.Format(";StorageLocation={0}",location.ToString()));
+            writer.WriteLine(string.Format(";StorageLocation={0}",StorageLocation));
 
             if (objecttype == ObjectType.ARRAY)
             {
@@ -1016,6 +1031,8 @@ namespace libEDSsharp
         public SortedDictionary<UInt16, ODentry> ods;
         public SortedDictionary<UInt16, ODentry> dummy_ods;
 
+        public StorageLocation storageLocation = new StorageLocation();
+
         public FileInfo fi;
         public DeviceInfo di;
         public MandatoryObjects md;
@@ -1189,7 +1206,7 @@ namespace libEDSsharp
 
                 if(kvp.Value.ContainsKey("StorageLocation"))
                 {
-                    Enum.TryParse(kvp.Value["StorageLocation"], out od.location);
+                    od.StorageLocation = kvp.Value["StorageLocation"];
                 }
 
                 if (od.objecttype == ObjectType.VAR)
@@ -1654,7 +1671,7 @@ mapped object  (subindex 1...8)
             }
 
             od_comparam.objecttype = ObjectType.REC;
-            od_comparam.location = StorageLocation.ROM;
+            od_comparam.StorageLocation = "ROM";
             od_comparam.accesstype = AccessType.ro;
             od_comparam.PDOtype = PDOMappingType.no;
 
@@ -1691,7 +1708,7 @@ mapped object  (subindex 1...8)
             }
 
             od_mapping.objecttype = ObjectType.REC;
-            od_mapping.location = StorageLocation.ROM;
+            od_mapping.StorageLocation = "ROM";
             od_mapping.accesstype = AccessType.rw; //Same as default but inconsistant with ROM above
             od_mapping.PDOtype = PDOMappingType.no;
 


### PR DESCRIPTION
- A new region can be added by selecting the memory combo box and selecting "add...".
- Those regions are used natively by the stack, but persistent storage needs to be provided by the user app like with the standard EEPROM region (eeprom read/write functions, OD entries for saving/restoring).
- A region can't be deleted directly. You have to remove all references, then it will not be stored to config files.
- You can't remove or change "ROM", "RAM", "EEPROM"
- in CanOpenNodeExporter.cs there are two lines  `if (!(od.location == 0 && location == StorageLocation.RAM))`. I've just converted this line to match the new variable names, but I have no idea what use case those lines cover. My files where correctly exported without this line included.

- Please have a close look at this...