### PR TITLE
Removed inconsistent line end

### DIFF
--- a/EDSTest/Form1.cs
+++ b/EDSTest/Form1.cs
@@ -609,7 +609,7 @@ namespace ODEditor
                     .GetManifestResourceStream("ODEditor." + "version.txt"))
             using (StreamReader reader = new StreamReader(stream))
             {
-                gitVersion = reader.ReadToEnd();
+                gitVersion = reader.ReadToEnd().TrimEnd('\n');
             }
             if (gitVersion == "")
             {

--- a/Tests/ExporterTests.cs
+++ b/Tests/ExporterTests.cs
@@ -37,13 +37,13 @@ namespace Tests
 
             string test = export_one_record_type(subod, "");
 
-            if (test != "           {(void*)&CO_OD_RAM.testRecord.testString1, 0xbe, 0x7 },\n")
+            if (test != "           {(void*)&CO_OD_RAM.testRecord.testString1, 0xbe, 0x7 }," + Environment.NewLine)
                 throw (new Exception("export_one_record_type() error test 1"));
 
             subod = new ODentry("Test String 2", 0x01, DataType.VISIBLE_STRING, new string('*', 255), EDSsharp.AccessType.ro, PDOMappingType.optional, od);
             test = export_one_record_type(subod, "");
 
-            if (test != "           {(void*)&CO_OD_RAM.testRecord.testString2, 0xa6, 0xff },\n")
+            if (test != "           {(void*)&CO_OD_RAM.testRecord.testString2, 0xa6, 0xff }," + Environment.NewLine)
                 throw (new Exception("export_one_record_type() error test 2"));
 
         }
@@ -77,7 +77,7 @@ namespace Tests
 
             string test = print_h_entry(od);
 
-            if (test != "/*2000      */ VISIBLE_STRING  testArray[32][4];\n")
+            if (test != "/*2000      */ VISIBLE_STRING  testArray[32][4];" + Environment.NewLine)
                 throw (new Exception("TestArrays() test 1 failed"));
 
 
@@ -110,7 +110,7 @@ namespace Tests
             od.subobjects.Add(0x01, new ODentry("LINE1", 0x01, DataType.UNSIGNED32, "0x01", EDSsharp.AccessType.ro, PDOMappingType.optional));
           
             string test = write_od_line(od);
-            if(test != "{0x1011, 0x7f, 0x06, 0, (void*)&CO_OD_RAM.testArray[0]},\n")
+            if(test != "{0x1011, 0x7f, 0x06, 0, (void*)&CO_OD_RAM.testArray[0]}," + Environment.NewLine)
                 throw (new Exception("TestArrayNoEntries() failed"));
 
 
@@ -129,7 +129,7 @@ namespace Tests
             od.subobjects.Add(0x01, new ODentry("LINE1", 0x01, DataType.UNSIGNED32, "0x01", EDSsharp.AccessType.ro, PDOMappingType.optional));
 
             test = write_od_line(od);
-            if (test != "{0x2000, 0x7f, 0x06, 0, (void*)&CO_OD_RAM.testArray[0]},\n")
+            if (test != "{0x2000, 0x7f, 0x06, 0, (void*)&CO_OD_RAM.testArray[0]}," + Environment.NewLine)
                 throw (new Exception("TestArrayNoEntries() failed"));
 
 
@@ -150,7 +150,7 @@ namespace Tests
             od.subobjects.Add(0x03, new ODentry("LINE1", 0x03, DataType.UNSIGNED32, "0x01", EDSsharp.AccessType.ro, PDOMappingType.optional));
 
             test = write_od_line(od);
-            if (test != "{0x1003, 0x03, 0x06, 0, (void*)&CO_OD_RAM.testArray[0]},\n")
+            if (test != "{0x1003, 0x03, 0x06, 0, (void*)&CO_OD_RAM.testArray[0]}," + Environment.NewLine)
                 throw (new Exception("TestArrayNoEntries() failed"));
 
 

--- a/libEDSsharp/CanOpenNodeExporter.cs
+++ b/libEDSsharp/CanOpenNodeExporter.cs
@@ -208,7 +208,7 @@ namespace libEDSsharp
                     specialarraylength = string.Format("[{0}]", od.Lengthofstring);
                 }
 
-                sb.AppendFormat("/*{0:x4}      */ {1,-15} {2}{3};\n", od.Index, od.datatype.ToString(), make_cname(od.parameter_name), specialarraylength);
+                sb.AppendLine($"/*{od.Index:x4}      */ {od.datatype.ToString(),-15} {make_cname(od.parameter_name)}{specialarraylength};");
             }
             else
             {
@@ -241,7 +241,7 @@ namespace libEDSsharp
                         return "";
 
                     lastname = name;
-                    sb.AppendFormat("/*{0:x4}      */ {1,-15} {2}[{3}];\n", od.Index, objecttypewords, make_cname(od.parameter_name), au[name]);
+                    sb.AppendLine($"/*{od.Index:x4}      */ {objecttypewords,-15} {make_cname(od.parameter_name)}[{au[name]}];");
                 }
                 else
                 {
@@ -252,11 +252,11 @@ namespace libEDSsharp
                     {
                         if (arrayspecial(od.Index, true))
                         {
-                            sb.AppendFormat("/*{0:x4}      */ {1,-15} {2}[1];\n", od.Index, objecttypewords, make_cname(od.parameter_name));
+                            sb.AppendLine($"/*{od.Index:x4}      */ {objecttypewords,-15} {make_cname(od.parameter_name)}[1];");
                         }
                         else
                         {
-                            sb.AppendFormat("/*{0:x4}      */ {1,-15} {2};\n", od.Index, objecttypewords, make_cname(od.parameter_name));
+                            sb.AppendLine($"/*{od.Index:x4}      */ {objecttypewords,-15} {make_cname(od.parameter_name)};");
                         }
                     }
                     else
@@ -275,7 +275,7 @@ namespace libEDSsharp
                             specialarraylength = string.Format("[{0}]", maxlength);
                         }
 
-                        sb.AppendFormat("/*{0:x4}      */ {1,-15} {2}{4}[{3}];\n", od.Index, objecttypewords, make_cname(od.parameter_name), od.Nosubindexes - 1, specialarraylength);
+                        sb.AppendLine($"/*{od.Index:x4}      */ {objecttypewords,-15} {make_cname(od.parameter_name)}{specialarraylength}[{od.Nosubindexes - 1}];");
                     }
                 }
             }
@@ -573,7 +573,7 @@ namespace libEDSsharp
 
                             ODSIs.Add(ODSI);
 
-                            ODSIout += (string.Format("        #define {0,-51} {1}\r\n", ODSI, kvp2.Key));
+                            ODSIout += ($"        #define {ODSI,-51} {kvp2.Key}{Environment.NewLine}");
                         }
 
                         file.Write(ODSIout);
@@ -700,11 +700,11 @@ file.WriteLine(@"/**************************************************************
                                 //so offset by one
                                 if (od.objecttype == ObjectType.ARRAY)
                                 {
-                                    ODAout += (string.Format("        #define {0,-51} {1}\r\n", string.Format("ODA_{0}_{1}", make_cname(od.parameter_name), make_cname(sub.parameter_name)), kvp2.Key - 1));
+                                    ODAout += ($"        #define {string.Format("ODA_{0}_{1}", make_cname(od.parameter_name), make_cname(sub.parameter_name)),-51} {kvp2.Key - 1}{Environment.NewLine}");
                                 }
                                 else
                                 {
-                                    ODAout += (string.Format("        #define {0,-51} {1}\r\n", string.Format("ODA_{0}_{1}", make_cname(od.parameter_name), make_cname(sub.parameter_name)), kvp2.Key));
+                                    ODAout += ($"        #define {string.Format("ODA_{0}_{1}", make_cname(od.parameter_name), make_cname(sub.parameter_name)),-51} {kvp2.Key}{Environment.NewLine}");
                                 }
                             }
 
@@ -926,7 +926,7 @@ const CO_OD_entry_t CO_OD[");
                 pdata = "0";
             }
 
-            sb.AppendFormat("{{0x{0:x4}, 0x{1:x2}, 0x{2:x2}, {3}, (void*){4}}},\n", od.Index, nosubindexs, flags, datasize, pdata);
+            sb.AppendLine($"{{0x{od.Index:x4}, 0x{nosubindexs:x2}, 0x{flags:x2}, {datasize}, (void*){pdata}}},");
 
             if (arrayspecial(od.Index, false))
             {
@@ -1280,7 +1280,7 @@ const CO_OD_entry_t CO_OD[");
                     count = 3; //CanOpenNode Fudging. Its only 3 paramaters for RX PDOS in the c code despite being a PDO_COMMUNICATION_PARAMETER
                 }
 
-                returndata.AppendFormat("/*0x{0:x4}*/ const CO_OD_entryRecord_t OD_record{0:x4}[{1}] = {{\n", od.Index, count);
+                returndata.AppendLine($"/*0x{od.Index:x4}*/ const CO_OD_entryRecord_t OD_record{od.Index:x4}[{count}] = {{");
 
                 string arrayaccess = "";
 
@@ -1302,7 +1302,7 @@ const CO_OD_entry_t CO_OD[");
                     arrayopen = false;
                 }
 
-                returndata.Append("};\r\n\r\n");
+                returndata.AppendLine($"}};{Environment.NewLine}");
             }
 
             return returndata.ToString();
@@ -1329,12 +1329,12 @@ const CO_OD_entry_t CO_OD[");
 
             if (sub.datatype != DataType.DOMAIN)
             {
-                sb.AppendFormat("           {{(void*)&{5}.{0}{4}.{1}, 0x{2:x2}, 0x{3:x} }},\n", cname, subcname, getflags(sub), datasize, arrayaccess, "CO_OD_" + sub.parent.StorageLocation);
+                sb.AppendLine($"           {{(void*)&{"CO_OD_" + sub.parent.StorageLocation}.{cname}{arrayaccess}.{subcname}, 0x{getflags(sub):x2}, 0x{datasize:x} }},");
             }
             else
             {
                 //Domain type MUST have its data pointer set to 0 for CanOpenNode
-                sb.AppendFormat("           {{(void*)0, 0x{2:x2}, 0x{3:x} }},\n", cname, subcname, getflags(sub), datasize, arrayaccess, "CO_OD_" + sub.parent.StorageLocation);
+                sb.AppendLine($"           {{(void*)0, 0x{getflags(sub):x2}, 0x{datasize:x} }},");
             }
 
             return sb.ToString();
@@ -1435,7 +1435,7 @@ const CO_OD_entry_t CO_OD[");
 
                 if (od.Nosubindexes == 0)
                 {
-                    sb.AppendFormat("/*{0:x4}*/ {1},\n", od.Index, formatvaluewithdatatype(od.defaultvalue, od.datatype));
+                    sb.AppendLine($"/*{od.Index:x4}*/ {formatvaluewithdatatype(od.defaultvalue, od.datatype)},");
                 }
                 else
                 {
@@ -1466,11 +1466,11 @@ const CO_OD_entry_t CO_OD[");
 
                     if (arrayspecial(od.Index, false))
                     {
-                        sb.Append("}},\n");
+                        sb.AppendLine("}},");
                     }
                     else
                     {
-                        sb.Append("},\n");
+                        sb.AppendLine("},");
                     }
 
                 }

--- a/libEDSsharp/eds.cs
+++ b/libEDSsharp/eds.cs
@@ -243,16 +243,16 @@ namespace libEDSsharp
         {
             string msg;
 
-            msg = "*****************************************************\n";
-            msg += String.Format("*{0,-51}*\n", String.Format("{0," + ((51 + infoheader.Length) / 2).ToString() + "}", infoheader));
-            msg += "*****************************************************\n";
+            msg = $"*****************************************************{Environment.NewLine}";
+            msg += $"*{String.Format("{0," + ((51 + infoheader.Length) / 2).ToString() + "}", infoheader),-51}*{Environment.NewLine}";
+            msg += $"*****************************************************{Environment.NewLine}";
 
             Type tx = this.GetType();
             FieldInfo[] fields = this.GetType().GetFields();
 
             foreach (FieldInfo f in fields)
             {
-                msg += string.Format("{0,-28}: {1}\n", f.Name, f.GetValue(this).ToString());
+                msg += $"{f.Name,-28}: {f.GetValue(this).ToString()}{Environment.NewLine}";
             }
 
             return msg;
@@ -378,13 +378,13 @@ namespace libEDSsharp
         {
             string msg;
 
-            msg = "*****************************************************\n";
-            msg += String.Format("*{0,-51}*\n", String.Format("{0," + ((51 + infoheader.Length) / 2).ToString() +  "}", infoheader));
-            msg += "*****************************************************\n";
-            msg += string.Format("\n{0} = {1}\n", countmsg, objectlist.Count);
+            msg = $"*****************************************************{Environment.NewLine}";
+            msg += $"*{String.Format("{0," + ((51 + infoheader.Length) / 2).ToString() + "}", infoheader),-51}*{Environment.NewLine}";
+            msg += $"*****************************************************{Environment.NewLine}";
+            msg += $"}}{Environment.NewLine}{countmsg} = {objectlist.Count}{Environment.NewLine}";
             foreach(KeyValuePair<int,int> kvp in objectlist)
             {
-                msg += string.Format("{0,-5}: {1:x4}\n", kvp.Key, kvp.Value);
+                msg += $"{kvp.Key,-5}: {kvp.Value:x4}{Environment.NewLine}";
             }
 
             return msg;
@@ -439,13 +439,13 @@ namespace libEDSsharp
         {
             string msg;
 
-            msg = "*****************************************************\n";
-            msg += String.Format("*{0,-51}*\n", String.Format("{0," + ((51 + infoheader.Length) / 2).ToString() + "}", infoheader));
-            msg += "*****************************************************\n";
-            msg += string.Format("\nLines = {0}\n", comments.Count);
+            msg = $"*****************************************************{Environment.NewLine}";
+            msg += $"*{String.Format("{0," + ((51 + infoheader.Length) / 2).ToString() + "}", infoheader),-51}*{Environment.NewLine}";
+            msg += $"*****************************************************{Environment.NewLine}";
+            msg += $"{Environment.NewLine}Lines = {comments.Count}{Environment.NewLine}";
             foreach (string s in comments)
             {
-                msg += string.Format("{0}\n",s);
+                msg += $"{s}{Environment.NewLine}";
             }
 
             return msg;


### PR DESCRIPTION
- https://github.com/robincornelius/libedssharp/issues/136
- changes from \n or \r\n to Environment.NewLine
- added TrimEnd('\n') to gitVersion because it always ends with a \n

I only touched libEDSsharp, because the endings in EDSEditorGUI are mostly for Messageboxes and don't matter.