### PR TITLE
add Makefile, auto-update timestamp, fix name conflict

### DIFF
--- a/EDSTest/DeviceInfoView.cs
+++ b/EDSTest/DeviceInfoView.cs
@@ -148,7 +148,8 @@ namespace ODEditor
 
                 eds.fi.EDSVersion = textBox_fileversion.Text;
 
-                eds.fi.ModificationDateTime = DateTime.Parse(textBox_modified_datetime.Text);
+                eds.fi.ModificationDateTime = DateTime.Now;
+                textBox_modified_datetime.Text = DateTime.Now.ToString();
 
                 eds.fi.ModifiedBy = textBox_modifiedby.Text;
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+# Requires mono-devel and msbuild:
+# https://www.mono-project.com/download/stable/
+
+APP := EDSTest
+
+all:
+	msbuild $(APP)
+
+clean:
+	$(RM) -r $(APP)/bin
+
+install:
+	cp -Tr $(APP)/bin/Debug /opt/EDSEditor

--- a/libEDSsharp/CanOpenNodeExporter.cs
+++ b/libEDSsharp/CanOpenNodeExporter.cs
@@ -372,6 +372,11 @@ namespace libEDSsharp
    typedef float64_t    REAL64; 
    typedef char_t       VISIBLE_STRING;
    typedef oChar_t      OCTET_STRING;
+
+   #ifdef DOMAIN
+   #undef DOMAIN
+   #endif
+
    typedef domain_t     DOMAIN;
 
 #ifndef timeOfDay_t


### PR DESCRIPTION
1. Adds a Makefile to build on linux using mono/msbuild
2. Changes the 'Device' tab's 'Update' button to set the 'Modification Date/Time' so the user doesn't have to type it in manually.
3. Fixed DOMAIN type name conflict from CANopenNode (https://github.com/CANopenNode/CANopenNode/issues/68)