### PR TITLE
Fix CANopenNode TPDO compatibilityEntry naming and index.

### DIFF
--- a/libEDSsharp/CanOpenNodeExporter.cs
+++ b/libEDSsharp/CanOpenNodeExporter.cs
@@ -87,8 +87,8 @@ namespace libEDSsharp
                     if (!od.Containssubindex(0x04))
                     {
                         compatfixed = true;
-                        ODentry compatability = new ODentry("comparability Entry", 0x05, DataType.UNSIGNED8, "0", EDSsharp.AccessType.ro, PDOMappingType.no);
-                        od.subobjects.Add(0x04, compatability);
+                        ODentry compatibility = new ODentry("compatibility entry", idx, DataType.UNSIGNED8, "0", EDSsharp.AccessType.ro, PDOMappingType.no, od);
+                        od.subobjects.Add(0x04, compatibility);
                     }
                 }
             }


### PR DESCRIPTION
CANopenNode calls the TPDO compatibility entries for `compatibilityEntry`. The current libedssharp code names them `comparabilityEntry`. Align with CANopenNode on the naming and fix the `ODentry` to have the correct index.

