### PR TITLE
Remove GPL license and copyright from header of generated CO_OD.{c,h}

### DIFF
--- a/libEDSsharp/CanOpenNodeExporter.cs
+++ b/libEDSsharp/CanOpenNodeExporter.cs
@@ -314,57 +314,13 @@ namespace libEDSsharp
             return sb.ToString();
         }
 
-        private void addGPLheader(StreamWriter file)
+        private void addHeader(StreamWriter file)
         {
             file.WriteLine(@"/*******************************************************************************
 
    File - CO_OD.c/CO_OD.h
    CANopen Object Dictionary.
 
-   Copyright (C) 2004-2008 Janez Paternoster
-
-   License: GNU Lesser General Public License (LGPL).
-
-   <http://canopennode.sourceforge.net>
-
-   (For more information see <CO_SDO.h>.)
-
-   This file is part of CANopenNode, an open source CANopen Stack.
-   Project home page is <https://github.com/CANopenNode/CANopenNode>.
-   For more information on CANopen see <http://www.can-cia.org/>.
- 
-   CANopenNode is free and open source software: you can redistribute
-   it and/or modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation, either version 2 of the
-   License, or (at your option) any later version.
-  
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-  
-   You should have received a copy of the GNU General Public License
-   along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
-   Following clarification and special exception to the GNU General Public
-   License is included to the distribution terms of CANopenNode:
-  
-   Linking this library statically or dynamically with other modules is
-   making a combined work based on this library. Thus, the terms and
-   conditions of the GNU General Public License cover the whole combination.
-  
-   As a special exception, the copyright holders of this library give
-   you permission to link this library with independent modules to
-   produce an executable, regardless of the license terms of these
-   independent modules, and to copy and distribute the resulting
-   executable under terms of your choice, provided that you also meet,
-   for each linked independent module, the terms and conditions of the
-   license of that module. An independent module is a module which is
-   not derived from or based on this library. If you modify this
-   library, you may extend this exception to your version of the
-   library, but you are not obliged to do so. If you do not wish
-   to do so, delete this exception statement from your version.
- 
    This file was automatically generated with libedssharp Object");
             
             file.Write("   Dictionary Editor v" + this.gitVersion);
@@ -382,7 +338,7 @@ namespace libEDSsharp
             StreamWriter file = new StreamWriter(folderpath + Path.DirectorySeparatorChar + "CO_OD.h");
 
 
-            addGPLheader(file);
+            addHeader(file);
 
             file.WriteLine("#pragma once");
             file.WriteLine("");
@@ -775,7 +731,7 @@ file.WriteLine(@"/**************************************************************
         {
             StreamWriter file = new StreamWriter(folderpath + Path.DirectorySeparatorChar + "CO_OD.c");
 
-            addGPLheader(file);
+            addHeader(file);
 
             file.WriteLine(@"#include ""CO_driver.h""
 #include ""CO_OD.h""


### PR DESCRIPTION
Remove GPL license and copyright from header of generated CO_OD.{c,h} files.

According to the author of CANopenNode the object dictionary files `CO_OD.h` and `CO_OD.c` can be under any license: https://github.com/CANopenNode/CANopenNode/issues/105