### PR TITLE
TIME

### DIFF
--- a/libEDSsharp/CanOpenNodeExporter.cs
+++ b/libEDSsharp/CanOpenNodeExporter.cs
@@ -457,7 +457,7 @@ namespace libEDSsharp
 
             file.WriteLine(string.Format("  #define CO_NO_EMERGENCY                {0}   //Associated objects: 1014, 1015", noEMCY));
 		
-            file.WriteLine(string.Format("  #define CO_NO_TS                       {0}   //Associated objects: 1012, 1013", noTS));
+            file.WriteLine(string.Format("  #define CO_NO_TIME                     {0}   //Associated objects: 1012, 1013", noTIME));
 
             file.WriteLine(string.Format("  #define CO_NO_SDO_SERVER               {0}   //Associated objects: 1200-127F", noSDOservers));
             file.WriteLine(string.Format("  #define CO_NO_SDO_CLIENT               {0}   //Associated objects: 1280-12FF", noSDOclients));
@@ -1397,7 +1397,7 @@ const CO_OD_entry_t CO_OD[");
         int distRXpdo = 0;
         int noSYNC = 0;
         int noEMCY = 0;
-        int noTS = 0;
+        int noTIME = 0;
 
         void countPDOS()
         {
@@ -1440,7 +1440,7 @@ const CO_OD_entry_t CO_OD[");
                     noEMCY = 1;
 
                 if (index == 0x1012)
-                    noTS = 1;
+                    noTIME = 1;
             }
 
         }


### PR DESCRIPTION
Hi Robin, 

I renamed TS by TIME on my previous commit for a better comprehension (did the same on CANopenNode side). 

OD_COB_ID_TIME (0x1012) defines TIME message CAN ID and if node is a consumer or a producer (bits 31 and 30). 

Should we add a default value when using "insert profile" "DS301" to initialise node as a TIME consumer with default CAN ID 0x100 (0x1012 = 0x80000100L) ?