### PR TITLE
Fix OD export errors, to keep compatibility with CANopenNode

### DIFF
--- a/libEDSsharp/CanOpenNodeExporter.cs
+++ b/libEDSsharp/CanOpenNodeExporter.cs
@@ -829,7 +829,7 @@ const CO_OD_entry_t CO_OD[CO_OD_NoOfElements] = {
             byte flags = getflags(od);
 
             DataType t = eds.Getdatatype(od);
-            int datasize = od.Sizeofdatatype();
+            int datasize = (int)Math.Ceiling((double)od.Sizeofdatatype() / (double)8.0);
 
             string odf;
 
@@ -1001,7 +1001,7 @@ const CO_OD_entry_t CO_OD[CO_OD_NoOfElements] = {
               flags |=0x40;
             }
 
-            int datasize = od.Sizeofdatatype();
+            int datasize = (int)Math.Ceiling((double)od.Sizeofdatatype() / (double)8.0);
 
             if (datasize > 1)
             {


### PR DESCRIPTION
Two fixes to keep compatibility with CANOpenNode. I am not aware of any change in CANopenNode, which changes CO_OD_getLength to returning length in bits instead of bytes. This would be a change in CANopenNOdes API.
Fix1: Sets the attribute correct when generating  CO_OD_entryRecord_t structures. 8 bits are still one byte.
Fix2: Length field in CO_OD_entry_t back to bytes.
