### PR TITLE
Fix: remove TIME_OF_DAY declarations

### DIFF
--- a/libEDSsharp/CanOpenNodeExporter.cs
+++ b/libEDSsharp/CanOpenNodeExporter.cs
@@ -443,21 +443,6 @@ namespace libEDSsharp
 
    typedef domain_t     DOMAIN;
 
-#ifndef timeOfDay_t
-    typedef union {
-        unsigned long long ullValue;
-        struct {
-            unsigned long ms:28;
-            unsigned reserved:4;
-            unsigned days:16;
-            unsigned reserved2:16;
-        };
-    }timeOfDay_t;
-#endif
-
-    typedef timeOfDay_t TIME_OF_DAY;
-    typedef timeOfDay_t TIME_DIFFERENCE;
-
 ");
 
             file.WriteLine("/*******************************************************************************");


### PR DESCRIPTION
TIME_OF_DAY is now defined on CO_TIME.h since https://github.com/CANopenNode/CANopenNode/commit/2d5d9a4eb982bfb31c65f64e5633907839999744