### PR TITLE
fix mixed line endings for documentation generator

### DIFF
--- a/libEDSsharp/CanOpenNodeExporter_V4.cs
+++ b/libEDSsharp/CanOpenNodeExporter_V4.cs
@@ -895,7 +895,6 @@ const OD_t {0} = {{
                         break;
                     case DataType.UNICODE_STRING:
                         data.cTypeString = true;
-                        data.cTypeMultibyte = true;
                         if (valueDefined || stringLength > 0)
                         {
                             List<string> words = new List<string>();

--- a/libEDSsharp/DocumentationGen.cs
+++ b/libEDSsharp/DocumentationGen.cs
@@ -177,7 +177,12 @@ namespace libEDSsharp
 
 This file was automatically generated with [libedssharp](https://github.com/robincornelius/libedssharp) Object Dictionary Editor v{8}
 
-* [Device Information](#device-information)* [PDO Mapping](#pdo-mapping)* [Communication Specific Parameters](#communication-specific-parameters)* [Manufacturer Specific Parameters](#manufacturer-specific-parameters)* [Device Profile Specific Parameters](#device-profile-specific-parameters)",
+* [Device Information](#device-information)
+* [PDO Mapping](#pdo-mapping)
+* [Communication Specific Parameters](#communication-specific-parameters)
+* [Manufacturer Specific Parameters](#manufacturer-specific-parameters)
+* [Device Profile Specific Parameters](#device-profile-specific-parameters)
+",
             eds.di.ProductName, eds.fi.Description,
             Path.GetFileName(eds.projectFilename), eds.fi.FileVersion,
             eds.fi.CreationDateTime, eds.fi.CreatedBy, eds.fi.ModificationDateTime, eds.fi.ModifiedBy,


### PR DESCRIPTION
Only mixed line endings changed to unix-style LF in one file.
Problem was, because generated markdown file had mixed line endings.