### PR TITLE
Improve Makefile build instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,14 @@
-# Requires mono-devel and msbuild:
-# https://www.mono-project.com/download/stable/
+# Build instructions tested on Ubuntu 20.10
+#
+# 1. Install mono-devel and msbuild:
+#
+#     https://www.mono-project.com/download/stable/
+#
+# 2. Install nuget packages
+#
+#    sudo apt install nuget
+#    nuget install SourceGrid -OutputDirectory packages
+#
 
 APP := EDSEditorGUI
 


### PR DESCRIPTION
This PR adds instructions to the Makefile to install SourceGrid with nuget before attempting the build.